### PR TITLE
Align post routes with OpenAPI

### DIFF
--- a/domain/post.go
+++ b/domain/post.go
@@ -11,4 +11,5 @@ type Post struct {
 // PostRepository defines the persistence functions for posts.
 type PostRepository interface {
 	Store(ctx context.Context, p *Post) error
+	ListByNewsletterID(ctx context.Context, newsletterID string) ([]Post, error)
 }

--- a/internal/delivery/http/post_handler.go
+++ b/internal/delivery/http/post_handler.go
@@ -17,9 +17,9 @@ type PostHandler struct {
 func NewPostHandler(r chi.Router, s *postusecase.Service) {
 	h := &PostHandler{service: s}
 
-	r.Route("/posts", func(r chi.Router) {
+	r.Route("/newsletters/{newsletterId}/posts", func(r chi.Router) {
 		r.Post("/", h.createPost)
-		r.Get("/{id}", h.getPost)
+		r.Get("/", h.listPosts)
 	})
 }
 
@@ -39,7 +39,15 @@ func (h *PostHandler) createPost(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("Post recieved"))
 }
 
-func (h *PostHandler) getPost(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
-	w.Write([]byte("TODO post with ID " + id))
+func (h *PostHandler) listPosts(w http.ResponseWriter, r *http.Request) {
+	newsletterID := chi.URLParam(r, "newsletterId")
+
+	posts, err := h.service.List(r.Context(), newsletterID)
+	if err != nil {
+		http.Error(w, "Failed to fetch posts", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(posts)
 }

--- a/internal/repository/postgres/post.go
+++ b/internal/repository/postgres/post.go
@@ -22,3 +22,25 @@ func (p *PostRepository) Store(ctx context.Context, post *domain.Post) error {
 	)
 	return err
 }
+
+func (p *PostRepository) ListByNewsletterID(ctx context.Context, newsletterID string) ([]domain.Post, error) {
+	rows, err := p.DB.QueryContext(ctx,
+		"SELECT title, content FROM posts WHERE newsletter_id = $1",
+		newsletterID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var posts []domain.Post
+	for rows.Next() {
+		var post domain.Post
+		if err := rows.Scan(&post.Title, &post.Content); err != nil {
+			return nil, err
+		}
+		posts = append(posts, post)
+	}
+
+	return posts, rows.Err()
+}

--- a/internal/usecase/post/service.go
+++ b/internal/usecase/post/service.go
@@ -20,3 +20,8 @@ func NewService(r domain.PostRepository) *Service {
 func (s *Service) Save(ctx context.Context, p *domain.Post) error {
 	return s.repo.Store(ctx, p)
 }
+
+// List returns posts of a newsletter.
+func (s *Service) List(ctx context.Context, newsletterID string) ([]domain.Post, error) {
+	return s.repo.ListByNewsletterID(ctx, newsletterID)
+}


### PR DESCRIPTION
## Summary
- align `PostHandler` routes with `/newsletters/{newsletterId}/posts`
- add list posts handler
- implement repository and service method to list posts
- extend `PostRepository` interface

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6845b56aa06083259a8da84f2ab53f05