### PR TITLE
Add pagination and consistent errors

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -25,7 +25,7 @@ components:
       type: apiKey
       name: Authorization
       in: header
-      description: 'Bearer access token sent as `Authorization: Bearer <token>`'
+      description: "Bearer access token sent as `Authorization: Bearer <token>`"
   schemas:
     # Auth namespace
     AuthRequest:
@@ -202,20 +202,20 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AuthRequest'
+              $ref: "#/components/schemas/AuthRequest"
       responses:
-        '201':
+        "201":
           description: Editor created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AuthResponse'
-        '400':
+                $ref: "#/components/schemas/AuthResponse"
+        "400":
           description: Invalid input
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
   /auth/login:
     post:
       tags:
@@ -226,20 +226,20 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AuthRequest'
+              $ref: "#/components/schemas/AuthRequest"
       responses:
-        '200':
+        "200":
           description: Authentication successful
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AuthResponse'
-        '401':
+                $ref: "#/components/schemas/AuthResponse"
+        "401":
           description: Invalid credentials
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
   /auth/refresh:
     post:
       tags:
@@ -250,9 +250,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RefreshRequest'
+              $ref: "#/components/schemas/RefreshRequest"
       responses:
-        '200':
+        "200":
           description: New access token
           content:
             application/json:
@@ -261,12 +261,12 @@ paths:
                 properties:
                   accessToken:
                     type: string
-        '401':
+        "401":
           description: Invalid refresh token
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
   /auth/password-reset/request:
     post:
       tags:
@@ -277,16 +277,16 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PasswordResetRequest'
+              $ref: "#/components/schemas/PasswordResetRequest"
       responses:
-        '200':
+        "200":
           description: Reset email sent
-        '400':
+        "400":
           description: Invalid email
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
   /auth/password-reset/confirm:
     post:
       tags:
@@ -297,16 +297,16 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PasswordResetConfirm'
+              $ref: "#/components/schemas/PasswordResetConfirm"
       responses:
-        '200':
+        "200":
           description: Password reset successful
-        '400':
+        "400":
           description: Invalid token or password
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
   /newsletters:
     get:
       tags:
@@ -315,14 +315,14 @@ paths:
       security:
         - bearerAuth: []
       responses:
-        '200':
+        "200":
           description: Array of newsletters
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Newsletter'
+                  $ref: "#/components/schemas/Newsletter"
     post:
       tags:
         - Newsletters
@@ -334,20 +334,20 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NewsletterCreate'
+              $ref: "#/components/schemas/NewsletterCreate"
       responses:
-        '201':
+        "201":
           description: Newsletter created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Newsletter'
-        '400':
+                $ref: "#/components/schemas/Newsletter"
+        "400":
           description: Invalid input
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
   /newsletters/{newsletterId}:
     get:
       tags:
@@ -363,18 +363,18 @@ paths:
             type: string
             format: uuid
       responses:
-        '200':
+        "200":
           description: Newsletter object
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Newsletter'
-        '404':
+                $ref: "#/components/schemas/Newsletter"
+        "404":
           description: Not found
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
     patch:
       tags:
         - Newsletters
@@ -393,20 +393,20 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NewsletterUpdate'
+              $ref: "#/components/schemas/NewsletterUpdate"
       responses:
-        '200':
+        "200":
           description: Updated newsletter
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Newsletter'
-        '404':
+                $ref: "#/components/schemas/Newsletter"
+        "404":
           description: Not found
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
     delete:
       tags:
         - Newsletters
@@ -421,14 +421,14 @@ paths:
             type: string
             format: uuid
       responses:
-        '204':
+        "204":
           description: Deleted successfully
-        '404':
+        "404":
           description: Not found
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
   /newsletters/{newsletterId}/posts:
     get:
       tags:
@@ -444,14 +444,14 @@ paths:
             type: string
             format: uuid
       responses:
-        '200':
+        "200":
           description: Array of posts
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Post'
+                  $ref: "#/components/schemas/Post"
     post:
       tags:
         - Posts
@@ -470,20 +470,20 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PostCreate'
+              $ref: "#/components/schemas/PostCreate"
       responses:
-        '201':
+        "201":
           description: Post published
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Post'
-        '400':
+                $ref: "#/components/schemas/Post"
+        "400":
           description: Invalid input
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
   /newsletters/{newsletterId}/subscribers:
     get:
       tags:
@@ -498,15 +498,34 @@ paths:
           schema:
             type: string
             format: uuid
+        - in: query
+          name: cursor
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: return results after this timestamp
+        - in: query
+          name: limit
+          required: false
+          schema:
+            type: integer
+          description: max number of subscribers to return
       responses:
-        '200':
-          description: Array of subscribers
+        "200":
+          description: Page of subscribers
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Subscriber'
+                type: object
+                properties:
+                  subscribers:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Subscriber"
+                  nextCursor:
+                    type: string
+                    format: date-time
   /newsletters/{newsletterId}/subscribe:
     post:
       tags:
@@ -524,16 +543,16 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SubscriptionRequest'
+              $ref: "#/components/schemas/SubscriptionRequest"
       responses:
-        '202':
+        "202":
           description: Confirmation email sent
-        '400':
+        "400":
           description: Invalid email
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
   /subscriptions/confirm:
     get:
       tags:
@@ -546,14 +565,14 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: Subscription confirmed
-        '400':
+        "400":
           description: Invalid or expired token
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
   /subscriptions/unsubscribe:
     get:
       tags:
@@ -566,14 +585,14 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: Unsubscribed successfully
-        '400':
+        "400":
           description: Invalid or expired token
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
   /auth/whoami:
     get:
       tags:
@@ -582,17 +601,17 @@ paths:
       security:
         - bearerAuth: []
       responses:
-        '200':
+        "200":
           description: Current user
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
-        '401':
+                $ref: "#/components/schemas/User"
+        "401":
           description: Not logged in
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
   security:
     - bearerAuth: []

--- a/domain/subscription.go
+++ b/domain/subscription.go
@@ -20,7 +20,11 @@ type SubscriptionRepository interface {
 	Create(ctx context.Context, s *Subscription) error
 	Confirm(ctx context.Context, token string) (*Subscription, error)
 	DeleteByToken(ctx context.Context, token string) error
-	ListByNewsletter(ctx context.Context, newsletterID string) ([]*Subscription, error)
+	// ListByNewsletter returns confirmed subscriptions for the given newsletter.
+	// Results are ordered by creation date descending. If cursor is provided,
+	// only subscriptions created before the cursor will be returned. The
+	// number of results is limited by limit.
+	ListByNewsletter(ctx context.Context, newsletterID, cursor string, limit int) ([]*Subscription, error)
 	GetByNewsletterEmail(ctx context.Context, newsletterID, email string) (*Subscription, error)
 	UpdateToken(ctx context.Context, id, token string) (*Subscription, error)
 }

--- a/internal/delivery/http/newsletter_handler.go
+++ b/internal/delivery/http/newsletter_handler.go
@@ -97,8 +97,12 @@ func (h *NewsletterHandler) getNewsletter(w http.ResponseWriter, r *http.Request
 
 	id := chi.URLParam(r, "newsletterId")
 	n, err := h.service.GetByID(r.Context(), id)
-	if err != nil || n == nil {
-		respondWithError(w, http.StatusNotFound, "not found")
+	if err != nil {
+		if err == newsletterusecase.ErrNotFound {
+			respondWithError(w, http.StatusNotFound, "not found")
+		} else {
+			respondWithError(w, http.StatusInternalServerError, "failed to fetch newsletter")
+		}
 		return
 	}
 
@@ -123,8 +127,12 @@ func (h *NewsletterHandler) updateNewsletter(w http.ResponseWriter, r *http.Requ
 
 	id := chi.URLParam(r, "newsletterId")
 	n, err := h.service.GetByID(r.Context(), id)
-	if err != nil || n == nil {
-		respondWithError(w, http.StatusNotFound, "not found")
+	if err != nil {
+		if err == newsletterusecase.ErrNotFound {
+			respondWithError(w, http.StatusNotFound, "not found")
+		} else {
+			respondWithError(w, http.StatusInternalServerError, "failed to fetch newsletter")
+		}
 		return
 	}
 	if n.OwnerID != user.ID {
@@ -163,8 +171,12 @@ func (h *NewsletterHandler) deleteNewsletter(w http.ResponseWriter, r *http.Requ
 
 	id := chi.URLParam(r, "newsletterId")
 	n, err := h.service.GetByID(r.Context(), id)
-	if err != nil || n == nil {
-		respondWithError(w, http.StatusNotFound, "not found")
+	if err != nil {
+		if err == newsletterusecase.ErrNotFound {
+			respondWithError(w, http.StatusNotFound, "not found")
+		} else {
+			respondWithError(w, http.StatusInternalServerError, "failed to fetch newsletter")
+		}
 		return
 	}
 	if n.OwnerID != user.ID {

--- a/internal/usecase/newsletter/service.go
+++ b/internal/usecase/newsletter/service.go
@@ -2,6 +2,7 @@ package newsletter
 
 import (
 	"context"
+	"errors"
 
 	"newsletter-go/domain"
 )
@@ -10,6 +11,8 @@ import (
 type Service struct {
 	repo domain.NewsletterRepository
 }
+
+var ErrNotFound = errors.New("newsletter not found")
 
 func NewService(r domain.NewsletterRepository) *Service {
 	return &Service{repo: r}
@@ -24,13 +27,26 @@ func (s *Service) Create(ctx context.Context, n *domain.Newsletter) error {
 }
 
 func (s *Service) GetByID(ctx context.Context, id string) (*domain.Newsletter, error) {
-	return s.repo.GetByID(ctx, id)
+	n, err := s.repo.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if n == nil {
+		return nil, ErrNotFound
+	}
+	return n, nil
 }
 
 func (s *Service) Update(ctx context.Context, n *domain.Newsletter) error {
+	if _, err := s.GetByID(ctx, n.ID); err != nil {
+		return err
+	}
 	return s.repo.Update(ctx, n)
 }
 
 func (s *Service) Delete(ctx context.Context, id string) error {
+	if _, err := s.GetByID(ctx, id); err != nil {
+		return err
+	}
 	return s.repo.Delete(ctx, id)
 }

--- a/internal/usecase/subscriber/service.go
+++ b/internal/usecase/subscriber/service.go
@@ -62,6 +62,14 @@ func (s *Service) Unsubscribe(ctx context.Context, token string) error {
 	return s.repo.DeleteByToken(ctx, token)
 }
 
-func (s *Service) List(ctx context.Context, newsletterID string) ([]*domain.Subscription, error) {
-	return s.repo.ListByNewsletter(ctx, newsletterID)
+func (s *Service) List(ctx context.Context, newsletterID, cursor string, limit int) ([]*domain.Subscription, string, error) {
+	subs, err := s.repo.ListByNewsletter(ctx, newsletterID, cursor, limit)
+	if err != nil {
+		return nil, "", err
+	}
+	next := ""
+	if len(subs) == limit {
+		next = subs[len(subs)-1].CreatedAt.Format(time.RFC3339)
+	}
+	return subs, next, nil
 }

--- a/internal/usecase/user/service.go
+++ b/internal/usecase/user/service.go
@@ -22,6 +22,12 @@ type Service struct {
 	authClient *auth.Client
 }
 
+var (
+	ErrMissingAuthHeader = errors.New("missing authorization header")
+	ErrEmptyToken        = errors.New("empty token")
+	ErrInvalidToken      = errors.New("invalid token")
+)
+
 func NewService(r domain.UserRepository, permitKey, creds string) *Service {
 	cfg := config.NewConfigBuilder(permitKey).WithPdpUrl("https://cloudpdp.api.permit.io").Build()
 	app, err := firebase.NewApp(context.Background(), nil, option.WithCredentialsFile(creds))
@@ -38,12 +44,12 @@ func NewService(r domain.UserRepository, permitKey, creds string) *Service {
 func (s *Service) tokenFromRequest(r *http.Request) (string, error) {
 	auth := r.Header.Get("Authorization")
 	if auth == "" {
-		return "", errors.New("missing authorization header")
+		return "", ErrMissingAuthHeader
 	}
 
 	token := strings.TrimSpace(strings.TrimPrefix(auth, "Bearer"))
 	if token == "" {
-		return "", errors.New("empty token")
+		return "", ErrEmptyToken
 	}
 
 	return token, nil
@@ -52,7 +58,7 @@ func (s *Service) tokenFromRequest(r *http.Request) (string, error) {
 func (s *Service) parseToken(ctx context.Context, tokenStr string) (string, error) {
 	t, err := s.authClient.VerifyIDToken(ctx, tokenStr)
 	if err != nil {
-		return "", err
+		return "", ErrInvalidToken
 	}
 	return t.UID, nil
 }


### PR DESCRIPTION
## Summary
- document subscriber pagination in OpenAPI
- add cursor and limit params for listing subscribers
- implement pagination logic in subscription repository and service
- propagate typed errors across services and handlers

## Testing
- `go test ./...` *(fails: access blocked)*
- `go vet ./...` *(fails: access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684ddc4e57848325ac6f674565bbf3f4