### PR TITLE
Implement per-subscriber post deliveries

### DIFF
--- a/db/migrations/20250608160246_add_post_delivery.sql
+++ b/db/migrations/20250608160246_add_post_delivery.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS post_delivery (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    post_id UUID NOT NULL REFERENCES post(id) ON DELETE CASCADE,
+    subscription_id UUID NOT NULL REFERENCES subscription(id) ON DELETE CASCADE,
+    opened BOOLEAN NOT NULL DEFAULT FALSE
+);
+-- +goose Down
+DROP TABLE IF EXISTS post_delivery;

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -159,6 +159,14 @@ components:
       required:
         - title
         - content
+    PostDeliveryInfo:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+        opened:
+          type: boolean
     # Subscribers namespace
     Subscriber:
       type: object
@@ -531,6 +539,58 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Post"
+  /posts/{postId}:
+    get:
+      tags:
+        - Posts
+      summary: Get post metrics
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: postId
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Post metrics
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  post:
+                    $ref: "#/components/schemas/Post"
+                  totalSend:
+                    type: integer
+                  totalOpened:
+                    type: integer
+                  deliveries:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/PostDeliveryInfo"
+  /post-deliveries/{deliveryId}/pixel:
+    get:
+      tags:
+        - Posts
+      summary: Track email open
+      parameters:
+        - in: path
+          name: deliveryId
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Tracking pixel
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
   /newsletters/{newsletterId}/subscribers:
     get:
       tags:

--- a/domain/post_delivery.go
+++ b/domain/post_delivery.go
@@ -1,0 +1,22 @@
+package domain
+
+import "context"
+
+// PostDelivery links a post with a subscriber and tracks open state.
+type PostDelivery struct {
+	ID             string
+	PostID         string
+	SubscriptionID string
+	Opened         bool
+}
+
+type PostDeliveryInfo struct {
+	Email  string
+	Opened bool
+}
+
+type PostDeliveryRepository interface {
+	Create(ctx context.Context, postID, subscriptionID string) (*PostDelivery, error)
+	MarkOpened(ctx context.Context, id string) error
+	ListByPost(ctx context.Context, postID string) ([]*PostDeliveryInfo, error)
+}

--- a/domain/subscription.go
+++ b/domain/subscription.go
@@ -23,7 +23,8 @@ type SubscriptionRepository interface {
 	// Results are ordered by creation date descending. If cursor is provided,
 	// only subscriptions created before the cursor will be returned. The
 	// number of results is limited by limit.
-	ListByNewsletter(ctx context.Context, newsletterID, cursor string, limit int) ([]*Subscription, error)
-	GetByNewsletterEmail(ctx context.Context, newsletterID, email string) (*Subscription, error)
-	UpdateToken(ctx context.Context, id, token string) (*Subscription, error)
+        ListByNewsletter(ctx context.Context, newsletterID, cursor string, limit int) ([]*Subscription, error)
+        ListByNewsletterAll(ctx context.Context, newsletterID string) ([]*Subscription, error)
+        GetByNewsletterEmail(ctx context.Context, newsletterID, email string) (*Subscription, error)
+        UpdateToken(ctx context.Context, id, token string) (*Subscription, error)
 }

--- a/internal/di/di.go
+++ b/internal/di/di.go
@@ -30,7 +30,7 @@ func NewContainer() *Container {
 	newsletterService := newsletterusecase.NewService(newsletterRepo)
 
 	repo := postgres.NewPostRepository(db.DB)
-	service := postusecase.NewService(repo, newsletterRepo)
+	deliveryRepo := postgres.NewPostDeliveryRepository(db.DB)
 
 	userRepo := postgres.NewUserRepository(db.DB)
 	resetRepo := postgres.NewPasswordResetRepository(db.DB)
@@ -49,6 +49,8 @@ func NewContainer() *Container {
 
 	subscriberRepo := postgres.NewSubscriptionRepository(db.DB)
 	subscriberService := subscriberusecase.NewService(subscriberRepo, mailerSvc)
+
+	service := postusecase.NewService(repo, newsletterRepo, subscriberRepo, deliveryRepo, mailerSvc)
 
 	return &Container{
 		PostService:       service,

--- a/internal/mailer/service.go
+++ b/internal/mailer/service.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/mailgun/mailgun-go/v4"
+
+	"newsletter-go/domain"
 )
 
 type Service struct {
@@ -95,4 +97,25 @@ func (s *Service) SendSubscriptionConfirmEmail(to, token string) error {
 		return err
 	}
 	return s.send(to, "Confirm Subscription", body)
+}
+
+type PostEmailData struct {
+	Title      string
+	Content    template.HTML
+	PixelURL   string
+	UnsubToken string
+}
+
+func (s *Service) SendPostEmail(to, token string, p *domain.Post, deliveryID string) error {
+	data := PostEmailData{
+		Title:      p.Title,
+		Content:    template.HTML(p.Content),
+		PixelURL:   fmt.Sprintf("http://localhost:3000/post-deliveries/%s/pixel", deliveryID),
+		UnsubToken: token,
+	}
+	body, err := s.render("post.html", data)
+	if err != nil {
+		return err
+	}
+	return s.send(to, p.Title, body)
 }

--- a/internal/mailer/templates/post.html
+++ b/internal/mailer/templates/post.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>{{.Title}}</title>
+</head>
+<body>
+    <h1>{{.Title}}</h1>
+    <div>{{.Content}}</div>
+    <img src="{{.PixelURL}}" alt="" width="1" height="1" style="display:none;"/>
+    <p><a href="http://localhost:3000/subscriptions/unsubscribe?token={{.UnsubToken}}">Unsubscribe</a></p>
+</body>
+</html>

--- a/internal/repository/postgres/post_delivery.go
+++ b/internal/repository/postgres/post_delivery.go
@@ -1,0 +1,58 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+
+	"newsletter-go/domain"
+)
+
+type PostDeliveryRepository struct {
+	DB *sql.DB
+}
+
+func NewPostDeliveryRepository(db *sql.DB) *PostDeliveryRepository {
+	return &PostDeliveryRepository{DB: db}
+}
+
+func (r *PostDeliveryRepository) Create(ctx context.Context, postID, subscriptionID string) (*domain.PostDelivery, error) {
+	var d domain.PostDelivery
+	err := r.DB.QueryRowContext(ctx,
+		`INSERT INTO post_delivery (post_id, subscription_id) VALUES ($1,$2) RETURNING id, opened`,
+		postID, subscriptionID,
+	).Scan(&d.ID, &d.Opened)
+	if err != nil {
+		return nil, err
+	}
+	d.PostID = postID
+	d.SubscriptionID = subscriptionID
+	return &d, nil
+}
+
+func (r *PostDeliveryRepository) MarkOpened(ctx context.Context, id string) error {
+	_, err := r.DB.ExecContext(ctx, `UPDATE post_delivery SET opened = TRUE WHERE id = $1 AND opened = FALSE`, id)
+	return err
+}
+
+func (r *PostDeliveryRepository) ListByPost(ctx context.Context, postID string) ([]*domain.PostDeliveryInfo, error) {
+	rows, err := r.DB.QueryContext(ctx,
+		`SELECT s.email, d.opened FROM post_delivery d JOIN subscription s ON s.id = d.subscription_id WHERE d.post_id = $1`,
+		postID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var infos []*domain.PostDeliveryInfo
+	for rows.Next() {
+		var info domain.PostDeliveryInfo
+		if err := rows.Scan(&info.Email, &info.Opened); err != nil {
+			return nil, err
+		}
+		infos = append(infos, &info)
+	}
+	if infos == nil {
+		infos = []*domain.PostDeliveryInfo{}
+	}
+	return infos, rows.Err()
+}

--- a/internal/repository/postgres/subscription.go
+++ b/internal/repository/postgres/subscription.go
@@ -81,6 +81,31 @@ func (r *SubscriptionRepository) ListByNewsletter(ctx context.Context, newslette
 	return subs, rows.Err()
 }
 
+func (r *SubscriptionRepository) ListByNewsletterAll(ctx context.Context, newsletterID string) ([]*domain.Subscription, error) {
+	rows, err := r.DB.QueryContext(ctx,
+		`SELECT id, newsletter_id, email, token, confirmed_at, created_at
+                 FROM subscription
+                 WHERE newsletter_id = $1 AND confirmed_at IS NOT NULL`,
+		newsletterID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var subs []*domain.Subscription
+	for rows.Next() {
+		var s domain.Subscription
+		if err := rows.Scan(&s.ID, &s.NewsletterID, &s.Email, &s.Token, &s.ConfirmedAt, &s.CreatedAt); err != nil {
+			return nil, err
+		}
+		subs = append(subs, &s)
+	}
+	if subs == nil {
+		subs = []*domain.Subscription{}
+	}
+	return subs, rows.Err()
+}
+
 func (r *SubscriptionRepository) GetByNewsletterEmail(ctx context.Context, newsletterID, email string) (*domain.Subscription, error) {
 	var s domain.Subscription
 	err := r.DB.QueryRowContext(ctx,


### PR DESCRIPTION
## Summary
- track deliveries per subscriber instead of post metrics
- send unique pixel URLs linked to delivery records
- expose post metrics with GET `/posts/{postId}`
- handle tracking pixel via `/post-deliveries/{deliveryId}/pixel`
- add database table `post_delivery`

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684dfe198cbc8325bbcfe9a321c3b833